### PR TITLE
Added min export cable cost

### DIFF
--- a/Base_Costs_Code.ipynb
+++ b/Base_Costs_Code.ipynb
@@ -68,7 +68,7 @@
     "FixedCost = 600000 # Costs  associated with the purchase and installation of electrical substations as well as the buildings required for housing the staff and additional equipment required for the running of the wind farm.\n",
     "\n",
     "ElectricityCostperkWh = 0.144 # 14.4 pence - £0.144\n",
-    "DiscountRate = 0.07 # average 6.375% #(5.75% to 7%)"
+    "DiscountRate = 0.07 # 7%"
    ]
   },
   {
@@ -103,9 +103,10 @@
     "print('Min depth cost per turbine = £',MinDepthCostPerTurbine) # prints result\n",
     "MinIACableCostPerTurbine = a*IACableCostperMeter # Min inter array cable costs\n",
     "\n",
-    "# MinCostperTurbTot currently excludes the export cable cost as hard to create a min figure per eah turbine \n",
     "MinCostperTurbTot = CostperTurbine+LandCostperTurbine+MaintenanceCostperTurbine+MinDepthCostPerTurbine+MinIACableCostPerTurbine # Total costs\n",
-    "nturb = (budget-FixedCost)/(MinCostperTurbTot)   # number of possible turbines with current budget\n",
+    "nnturb = (budget-FixedCost)/(MinCostperTurbTot)# number of possible turbines with current budget\n",
+    "MinExportCableCostPerTurbine = (TooCloseShore*HVACCableCostperMeter)/nnturb\n",
+    "nturb = (budget-FixedCost)/(MinCostperTurbTot+MinExportCableCostPerTurbine)\n",
     "nturb = math.floor(nturb) # rounds down as cannot have fraction of a turbine\n",
     "minarea = minareaperturbine*nturb # Overall minimum area considering the amount of turbines\n",
     "maxarea = nturb*(1/2)*(math.sqrt(3))*(b**2) # Careful this isn't bigger than the entire size of the scaled nsea86 sea floor.\n",


### PR DESCRIPTION
Added onto the calculation of the initial number of turbines by adding in the minimum export cable costs per turbine. Determined via the minimum distance from shore, export cable cost, and number of turbines (which is calculated previously with the minimum total costs excluding the export cables)